### PR TITLE
Add optimizely revenue and stylist dimension

### DIFF
--- a/src-cljs/storefront/accessors/stylists.cljs
+++ b/src-cljs/storefront/accessors/stylists.cljs
@@ -1,0 +1,6 @@
+(ns storefront.accessors.stylists
+    (:require [storefront.keypaths :as keypaths]))
+
+(defn own-store? [data]
+  (= (get-in data keypaths/user-store-slug)
+     (get-in data keypaths/store-slug)))

--- a/src-cljs/storefront/components/slideout_nav.cljs
+++ b/src-cljs/storefront/components/slideout_nav.cljs
@@ -6,6 +6,7 @@
             [storefront.keypaths :as keypaths]
             [storefront.routes :as routes]
             [storefront.accessors.taxons :refer [taxon-path-for default-nav-taxon-path default-stylist-taxon-path]]
+            [storefront.accessors.stylists :refer [own-store?]]
             [storefront.messages :refer [send]]
             [storefront.hooks.experiments :as experiments]))
 
@@ -46,10 +47,6 @@
 
 (defn logged-in? [data]
   (boolean (get-in data keypaths/user-email)))
-
-(defn own-store? [data]
-  (= (get-in data keypaths/user-store-slug)
-     (get-in data keypaths/store-slug)))
 
 (defn shop-now-attrs [data]
   (if (experiments/bundle-builder? data)

--- a/src-cljs/storefront/hooks/experiments.cljs
+++ b/src-cljs/storefront/hooks/experiments.cljs
@@ -10,9 +10,13 @@
 (defn remove-optimizely []
   (remove-tags "optimizely"))
 
-(defn track-event [event-name]
+(defn set-dimension [dimension-name value]
   (when (.hasOwnProperty js/window "optimizely")
-    (.push js/optimizely (clj->js ["trackEvent" event-name]))))
+    (.push js/optimizely (clj->js ["setDimensionValue" dimension-name value]))))
+
+(defn track-event [event-name & [opts]]
+  (when (.hasOwnProperty js/window "optimizely")
+    (.push js/optimizely (clj->js ["trackEvent" event-name opts]))))
 
 (defn display-variation [data variation]
   (contains? (get-in data keypaths/optimizely-variations)


### PR DESCRIPTION
- Move own-store? to new stylists accessors
- Set stylist dimension only when stylist is on own store
  both on add-to-bag and place-order
- Send revenue tracking on "place-order"