### PR TITLE
Change the weight on closures description

### DIFF
--- a/src-cljs/storefront/components/category.cljs
+++ b/src-cljs/storefront/components/category.cljs
@@ -236,7 +236,7 @@
       "Silk and Lace Materials"
       "Colors: 1B and #613 Blonde"
       "14\" and 18\" Length Bundles"
-      "3.5 ounces")
+      "1.2 ounces")
 
     "blonde"
     '("100% Human Virgin Hair"


### PR DESCRIPTION
We had the weight as 3.5 ounces for closures but that is incorrect.
The correct weight is 1.2 ounces.