### PR TITLE
Update the label for Orders & Commissions

### DIFF
--- a/src-cljs/storefront/components/slideout_nav.cljs
+++ b/src-cljs/storefront/components/slideout_nav.cljs
@@ -101,7 +101,7 @@
             (when (own-store? data)
               [:div
                [:li
-                [:a (close-and-route data events/navigate-stylist-commissions) "Orders & Commissions"]]
+                [:a (close-and-route data events/navigate-stylist-commissions) "Commissions & Payouts"]]
                [:li
                 [:a (close-and-route data events/navigate-stylist-bonus-credit) "Bonus Credit"]]
                [:li


### PR DESCRIPTION
The flyout menu and desktop menu have different labels for "Commissions
& Payouts"