### PR TITLE
Update the copy for Blog link in menu

### DIFF
--- a/src-cljc/storefront/components/header.cljc
+++ b/src-cljc/storefront/components/header.cljc
@@ -160,7 +160,7 @@
      "Our Guarantee")
     (menu-link {:href           slideout-nav/blog-url
                 :on-mouse-enter close-shopping}
-     "Real Beauty")]))
+     "Real Beautiful")]))
 
 (defn shopping-column [items col-count]
   {:pre [(zero? (mod 12 col-count))]}

--- a/src-cljc/storefront/components/slideout_nav.cljc
+++ b/src-cljc/storefront/components/slideout_nav.cljc
@@ -209,7 +209,7 @@
                          :data-test "content-guarantee")
                   "Our guarantee")]
    [:li (menu-row {:href blog-url}
-                  "Real Beauty blog")]
+                  "Real Beautiful blog")]
    [:li (menu-row (assoc (utils/route-to events/navigate-content-about-us)
                          :data-test "content-about-us")
                   "About us")]


### PR DESCRIPTION
The blog should be called ‘Real Beautiful’ instead of what is currently
there (‘Real Beauty’)