### PR TITLE
Fix Typo in Hamburger and on Loose Wave Category Page [#nodeps]

### DIFF
--- a/src-cljc/catalog/categories.cljc
+++ b/src-cljc/catalog/categories.cljc
@@ -140,7 +140,7 @@
     :slug         "loose-wave"
     :criteria     {:product/department #{"hair"} :hair/texture #{"loose-wave"}}
     :filter-tabs  [:hair/family :hair/origin :hair/base-material :hair/color]
-    :copy         {:description (copy "For hair that holds a curl beautifully, a"
+    :copy         {:description (copy "For hair that holds a curl beautifully,"
                                       "our collection of 100% virgin Loose Wave hair"
                                       "is the perfect foundation for all your carefree,"
                                       "flirty, wavy looks.")}

--- a/src-cljc/storefront/components/slideout_nav.cljc
+++ b/src-cljc/storefront/components/slideout_nav.cljc
@@ -311,7 +311,7 @@
                 [:li {:key (:slug option)}
                  (major-menu-row
                   (utils/fake-href events/menu-traverse-out {:criteria (assoc criteria (:slug current-step) #{(:slug option)})})
-                  [:span.flex-auto (:label option)])]))))]]])))
+                  [:span.flex-auto.titleize (:label option)])]))))]]])))
 
 (defn slideout-component
   [{:keys [user store promo-data shopping signed-in new-taxon-launch?] :as data}


### PR DESCRIPTION
Loose Wave Category: typo in ze description ", a our collection"
Shop Closures & Frontals menu page: "360 frontals" everywhere else the
F is capitalized