### PR TITLE
Remove 'taken down' copy from match-stylist page

### DIFF
--- a/src-cljc/adventure/match_stylist.cljc
+++ b/src-cljc/adventure/match_stylist.cljc
@@ -5,7 +5,7 @@
 
 (defn ^:private query [data]
   {:prompt               "We'll match you with a top stylist, guaranteed."
-   :mini-prompt          "If you don’t love the install, we’ll pay for you to get it taken down and redone. It’s a win-win!"
+   :mini-prompt          "If you don’t love the install, we’ll pay for you to get it redone. It’s a win-win!"
    :background-overrides {:class "bg-adventure-match-stylist"}
    :data-test            "adventure-match-stylist"
    :current-step         2


### PR DESCRIPTION
because we don't pay for take downs